### PR TITLE
LRCI-610 Do not setup dummy proxy for modules integration tests

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2233,7 +2233,10 @@ log.sanitizer.enabled=false</echo>
 
 							<echo>Executing Gradle task in directory "modules": testIntegration.</echo>
 
-							<setup-test-batch-testable-tomcat test.portal.bundle.version="@{test.portal.bundle.version}" />
+							<setup-test-batch-testable-tomcat
+								setup.proxy="false"
+								test.portal.bundle.version="@{test.portal.bundle.version}"
+							/>
 
 							<antcall target="start-app-server-preserve-liferay-home" />
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-610

Hi Koor, please check if this change should be applied to other kind of batches (unit, modules-unit, integration), you can send it in if everything looks okay. 